### PR TITLE
Exclude unneeded 3rd party css from dist css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,9 @@ module.exports = function(grunt) {
           'node_modules/leaflet.photon/leaflet.photon.css',
           'node_modules/leaflet.locatecontrol/dist/L.Control.Locate.css',
           'src/**/*.css',
-          '!src/tiny.css'
+          '!src/tiny.css',
+          '!src/bootstrap.min.css',
+          '!src/fontello-embedded.css',
         ],
         dest: 'dist/latest/<%= pkg.name %>.css'
       },


### PR DESCRIPTION
This PR excludes unneded 3rd party css (i.e. `bootstrap.min.css` and `fontello-embedded.css`) from `stadtnavi-widget.css`. 