### PR TITLE
Add support for pre-defined coordinates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,11 +21,19 @@ To use it create a `<div>`, give it an ID and at least `200px` height and execut
 new StadtnaviAddressBox(divId, title, address, options);
 ```
 
+or, if the coordinates are known and no on-the-fly geocoding is required:
+
+```js
+new StadtnaviAddressBox(divId, title, address, options, lat, lon);
+```
+
 #### Arguments
 
 - `divId`: ID of the `<div>` element into which the interactive map is placed.
 - `title`: Name of the place for which the address box is for. This can be choosen freely and is used only for display purposes.
-- `address`: A full address with street name, house number, postal code and city. This is used for geolocating the place on the map so precise information is required.
+- `address`: A full address with street name, house number, postal code and city. This is used for geolocating the place on the map so precise information is required, in case lat/lon are unknown.
+- `lat`: Optional latitude value (-90 <=lat <= 90) for locating the place.
+- `lon`: Optional longitude value (-180 <=lat <= 180) for locating the place.
 
 #### Options
 

--- a/src/demo.html
+++ b/src/demo.html
@@ -77,21 +77,24 @@ new StadtnaviLocationSelector('widget-1', {
       </section>
 
       <section>
-        <h2 class="mt-5">Address box</h2>
+        <h2 class="mt-5">Address box with well-known coordinates</h2>
 
         <h4>JavaScript code</h4>
         <pre>
-new StadtnaviAddressBox('widget-2', "Volkshochschule Außenstelle Ehningen", "Gartenstraße 11, 71139 Ehningen", {});</pre>
+new StadtnaviAddressBox('widget-2', "Volkshochschule Außenstelle Ehningen", "Gartenstraße 11, 71139 Ehningen", {}, 48.659697, 8.943804);</pre>
 
         <div id='widget-2' class="stadtnavi-widget"></div>
 
         <script type="text/javascript">
-          new StadtnaviAddressBox('widget-2', "Volkshochschule Außenstelle Ehningen", "Gartenstraße 11, 71139 Ehningen", {});
+          new StadtnaviAddressBox('widget-2', "Volkshochschule Außenstelle Ehningen", "Gartenstraße 11, 71139 Ehningen", {}, 48.659697, 8.943804);
         </script>
 
       </section>
 
+
       <section>
+        <h2 class="mt-5">Address box with on-the-fly geocoding</h2>
+
         <h4>JavaScript code</h4>
         <pre>
 new StadtnaviAddressBox('widget-3', "Rathaus Bietigheim-Bissingen", "Marktplatz 8, 74321 Bietigheim-Bissingen", {});</pre>


### PR DESCRIPTION
This PR adds optional parameters lat/lon to specify coords to locate the marker, if in case no geocoding is required/intended.

(Another option would have been to use the option's center property, but I chose to be explicit and use propert arguements. They are appended after the options, as they are optional and to be backward compatible for existing clients)