### PR TITLE
Add iframe demo

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,6 +85,10 @@ module.exports = function(grunt) {
         src: 'src/tiny.html',
         dest: 'dist/tiny.html'
       },
+      iframedemo: {
+        src: 'src/iframe.html',
+        dest: 'dist/iframe.html'
+      },
     },
     watch: {
       files: ['Gruntfile.js', 'src/**/*.js', 'src/**/*.css', 'src/**/*.html', 'src/**/*.html', 'images/*', 'test/**/*.js'],

--- a/src/demo.html
+++ b/src/demo.html
@@ -176,6 +176,19 @@ new StadtnaviAddressBox('widget-5', "Bahnhof Angermünde", "Bahnhofsplatz, 16278
 
       </section>
 
+      <section>
+
+        <h2 class="mt-5">Address box via IFrame</h2>
+
+        <h4>HTML code</h4>
+        <pre>&lt;iframe src="iframe.html?address=Marktplatz 5, 71083 Herrenberg&name=Rathaus&lat=48.5965246&lon=8.8704940"
+          width="100%" height="500" title="Adress Box IFrame Demo"/&gt;</pre>
+
+        <div id='widget-6' class="stadtnavi-widget">
+           <iframe src="iframe.html?address=Marktplatz 5, 71083 Herrenberg&name=Rathaus&lat=48.5965246&lon=8.8704940" width="100%" height="500" title="Adress Box IFrame Demo"/>
+        </div>
+      </section>
+
     </main>
 
 

--- a/src/iframe.html
+++ b/src/iframe.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>stadtnavi</title>
+
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- widget imports -->
+    <link rel="stylesheet" href="latest/stadtnavi-widget.css"/>
+    <script src="latest/stadtnavi-widget.js"></script>
+    <style>
+      body {
+        margin: 0px;
+      }
+      .stadtnavi-widget {
+        width: 100%;
+        height: 100vh;
+      }
+    </style>
+
+  </head>
+  <body>
+    <div id='widget' class="stadtnavi-widget"></div>
+
+    <script type="text/javascript">
+      let params = new URLSearchParams(document.location.search);
+      new StadtnaviAddressBox('widget', params.get("name"), params.get("address"), {
+        pinPrimaryColor: params.get("pinPrimaryColor") || "#9FC727",
+        pinSecondaryColor: params.get("pinSecondaryColor") || "#FFFFFF",
+      }, 
+      params.get("lat"),
+      params.get("lon"));
+    </script>
+  </body>
+</html>
+
+


### PR DESCRIPTION
This PR adds a demo for an iframe.html to illustrate how the stadtnavi widget could be embedded via an IFrame.

Note: The demo uses explicitly provided lat/lon values, which depends on #4. 